### PR TITLE
Draft: Implement CowSwap quoting API

### DIFF
--- a/src/cow_api.py
+++ b/src/cow_api.py
@@ -1,0 +1,189 @@
+"""
+Utilities for internacting with the CowSwap API.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+import json
+import re
+from typing import Any, Optional
+
+import requests
+
+from src.models import Address, AppData, Network
+
+DEFAULT_BASE_URL = "https://api.cow.fi"
+
+class CowApi:
+    """
+    CowSwap orderbook API client.
+    """
+
+    def __init__(self, url: str):
+        """
+        Creates a new instance of the CowSwap API client.
+        :param url: the API base URL
+        """
+        self.url = url
+
+    @classmethod
+    def for_network(cls, network: Network) -> CowApi:
+        """
+        Create a new instance of the CowSwap API client with the default base
+        URL for the specified network.
+        :param network: the network
+        """
+        network_name = None
+        if network == Network.MAINNET:
+            network_name = "mainnet"
+        elif network == Network.GCHAIN:
+            network_name = "xdai"
+        else:
+            raise ValueError(f"unsupported network {network}")
+        return cls(f"{DEFAULT_BASE_URL}/{network_name}")
+
+    def _url(self, path: str) -> str:
+        return f"{self.url}/{path}"
+
+    def quote(self, request: QuoteRequst) -> QuoteResponse:
+        print(self._url("api/v1/quote"))
+        response = requests.post(self._url("api/v1/quote"), json=request.to_json())
+        return QuoteResponse.from_json(response.json())
+
+
+class TokenBalance(Enum):
+    """
+    The kind of token balance to use for trading.
+    """
+    ERC20 = "erc20"
+    EXTERNAL = "external"
+    INTERNAL = "internal"
+
+
+class OrderKind(Enum):
+    """
+    The kind of order.
+    """
+    SELL = "sell"
+    BUY = "buy"
+
+
+class PriceQuality(Enum):
+    """
+    The kind of order.
+    """
+    FAST = "fast"
+    OPTIMAL = "optimal"
+
+
+@dataclass
+class QuoteRequest:
+    """
+    A CowSwap API quote request.
+    """
+
+    from_: Address
+    sell_token: Address
+    buy_token: Address
+    valid_to: int
+    kind: OrderKind
+
+    sell_amount_before_fee: Optional[int] = None
+    sell_amount_after_fee: Optional[int] = None
+    buy_amount_after_fee: Optional[int] = None
+
+    receiver: Optional[Address] = None
+    app_data: AppData = AppData.zero()
+    partially_fillable: bool = False
+    sell_token_balance: TokenBalance = TokenBalance.ERC20
+    buy_token_balance: TokenBalance = TokenBalance.ERC20
+    price_quality: Optional[PriceQuality] = None
+
+    def to_json(self) -> dict[str, Any]:
+        """
+        Converts a request instance to a dictionary for JSON serialization.
+        """
+
+        # Do some name re-naming. In the future, it may be easier use a library
+        # for serialization like `marshmallow`.
+        value = {
+            "sellToken": self.sell_token.address,
+            "buyToken": self.buy_token.address,
+            "validTo": self.valid_to,
+            "appData": self.app_data.value,
+            "kind": self.kind.value,
+            "partiallyFillable": self.partially_fillable,
+            "sellTokenBalance": self.sell_token_balance.value,
+            "buyTokenBalance": self.buy_token_balance.value,
+            "from": self.from_.address,
+        }
+        if self.receiver is not None:
+            value["receiver"] = self.receiver.address
+        if self.price_quality is not None:
+            value["priceQuality"] = self.price_quality.value
+        if self.kind == OrderKind.SELL and self.sell_amount_before_fee is not None and self.sell_amount_after_fee is None and self.buy_amount_after_fee is None:
+            value["sellAmountBeforeFee"] = str(self.sell_amount_before_fee)
+        elif self.kind == OrderKind.SELL and self.sell_amount_before_fee is None and self.sell_amount_after_fee is not None and self.buy_amount_after_fee is None:
+            value["sellAmountAfterFee"] = str(self.sell_amount_after_fee)
+        elif self.kind == OrderKind.BUY and self.sell_amount_before_fee is None and self.sell_amount_after_fee is None and self.buy_amount_after_fee is not None:
+            value["buyAmountAfterFee"] = str(self.buy_amount_after_fee)
+        else:
+            raise ValueError("must specify exactly one sell/buy amount matching order kind")
+
+        return value
+
+
+@dataclass
+class Quote:
+    """
+    A quoted CowSwap order.
+    """
+    sell_token: Address
+    buy_token: Address
+    receiver: Optional[Address]
+    sell_amount: int
+    buy_amount: int
+    valid_to: int
+    app_data: AppData
+    fee_amount: int
+    kind: OrderKind
+    partially_fillable: bool
+    sell_token_balance: TokenBalance
+    buy_token_balance: TokenBalance
+
+
+@dataclass
+class QuoteResponse:
+    """
+    A CowSwap quote response.
+    """
+    quote: Quote
+    from_: Address
+    expiration: datetime
+
+    @classmethod
+    def from_json(cls, value: dict[str, Any]) -> QuoteResponse:
+        qvalue = value["quote"]
+        return QuoteResponse(
+            quote = Quote(
+                sell_token = Address(qvalue["sellToken"]),
+                buy_token = Address(qvalue["buyToken"]),
+                receiver = None if qvalue["receiver"] is None else Address(qvalue["receiver"]),
+                sell_amount = int(qvalue["sellAmount"]),
+                buy_amount = int(qvalue["buyAmount"]),
+                valid_to = int(qvalue["validTo"]),
+                app_data = AppData(qvalue["appData"]),
+                fee_amount = int(qvalue["feeAmount"]),
+                kind = OrderKind(qvalue["kind"]),
+                partially_fillable = bool(qvalue["partiallyFillable"]),
+                sell_token_balance = TokenBalance(qvalue["sellTokenBalance"]),
+                buy_token_balance = TokenBalance(qvalue["buyTokenBalance"]),
+            ),
+            from_ = Address(value["from"]),
+            # The date time we get is not-quite-ISO format. Specifically, it has
+            # 3 too many digits in the fractional part and uses Z to denote the
+            # UTC timezone - strip this suffix to parse the datetime.
+            expiration = datetime.fromisoformat(re.sub(r'\d\d\dZ$', "", value["expiration"]))
+        )

--- a/src/models.py
+++ b/src/models.py
@@ -4,6 +4,7 @@ Common location for shared resources throughout the project.
 from __future__ import annotations
 
 import re
+import random
 from datetime import datetime, timedelta
 from enum import Enum
 
@@ -69,3 +70,43 @@ class AccountingPeriod:
         return "-to-".join(
             [self.start.strftime("%Y-%m-%d"), self.end.strftime("%Y-%m-%d")]
         )
+
+
+class AppData:
+    """
+    A CowSwap app data.
+    """
+
+    def __init__(self, value: str):
+        if AppData._is_valid(value):
+            self.value: str = value.lower()
+        else:
+            raise ValueError(f"invalid app data {value}")
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, AppData) and self.value == other.value
+
+    def __hash__(self) -> int:
+        return self.value.__hash__()
+
+    @classmethod
+    def zero(cls) -> AppData:
+        """
+        Returns the zero app data.
+        """
+
+        return cls("0x0000000000000000000000000000000000000000000000000000000000000000")
+
+    @classmethod
+    def random(cls) -> AppData:
+        return cls(f"0x{random.randrange(2**256):064x}")
+
+    @staticmethod
+    def _is_valid(value: str) -> bool:
+        match_result = re.match(
+            pattern=r"^(0x)?[0-9a-f]{64}$", string=value, flags=re.IGNORECASE
+        )
+        return match_result is not None

--- a/tests/e2e/test_cow_api.py
+++ b/tests/e2e/test_cow_api.py
@@ -1,0 +1,23 @@
+import unittest
+
+from src.cow_api import CowApi, OrderKind, QuoteRequest
+from src.models import Address, AppData, Network
+
+
+class TestCowApi(unittest.TestCase):
+    def test_quote(self):
+        cow = CowApi.for_network(Network.MAINNET)
+        response = cow.quote(QuoteRequest(
+            sell_token=Address("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+            buy_token=Address("0x6810e776880c02933d47db1b9fc05908e5386b96"),
+            valid_to=0xffffffff,
+            app_data=AppData.random(),
+            kind=OrderKind.SELL,
+            from_=Address("0x0000000000000000000000000000000000000000"),
+            sell_amount_before_fee=10**18,
+        ))
+        self.assertEqual(response.quote.sell_amount + response.quote.fee_amount, 10**18)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_cow_api.py
+++ b/tests/unit/test_cow_api.py
@@ -1,0 +1,116 @@
+import unittest
+from datetime import datetime
+import json
+
+from src.cow_api import CowApi, OrderKind, QuoteRequest, QuoteResponse, Quote, TokenBalance
+from src.models import Address, AppData, Network
+
+
+class TestCowApi(unittest.TestCase):
+    def test_default_base_url(self):
+        cow = CowApi.for_network(Network.MAINNET)
+        self.assertEqual(cow.url, "https://api.cow.fi/mainnet")
+
+
+class TestQuoteRequest(unittest.TestCase):
+    def test_json_serialization(self):
+        quote = QuoteRequest(
+            sell_token=Address("0x1111111111111111111111111111111111111111"),
+            buy_token=Address("0x2222222222222222222222222222222222222222"),
+            receiver=Address("0x3333333333333333333333333333333333333333"),
+            valid_to=42,
+            kind=OrderKind.SELL,
+            from_=Address("0x4444444444444444444444444444444444444444"),
+            sell_amount_after_fee=10**18,
+        )
+        self.assertEqual(quote.to_json(), {
+            "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "buyToken": "0x2222222222222222222222222222222222222222",
+            "buyTokenBalance": "erc20",
+            "from": "0x4444444444444444444444444444444444444444",
+            "kind": "sell",
+            "partiallyFillable": False,
+            "receiver": "0x3333333333333333333333333333333333333333",
+            "sellAmountAfterFee": "1000000000000000000",
+            "sellToken": "0x1111111111111111111111111111111111111111",
+            "sellTokenBalance": "erc20",
+            "validTo": 42
+        })
+
+    def test_json_serialization_errors(self):
+        def empty_quote() -> QuoteRequest:
+            return QuoteRequest(
+                Address.zero(),
+                Address.zero(),
+                Address.zero(),
+                0,
+                OrderKind.SELL,
+            )
+
+        # missing amounts
+        with self.assertRaises(ValueError):
+            q = empty_quote()
+            q.to_json()
+        # duplicate amounts
+        with self.assertRaises(ValueError):
+            q = empty_quote()
+            q.sell_amount_after_fee = 0
+            q.sell_amount_before_fee = 0
+            q.to_json()
+        # buy amount for sell order
+        with self.assertRaises(ValueError):
+            q = empty_quote()
+            q.kind = OrderKind.SELL
+            q.buy_amount_after_fee = 0
+            q.to_json()
+        # sell amount for buy order
+        with self.assertRaises(ValueError):
+            q = empty_quote()
+            q.kind = OrderKind.BUY
+            q.sell_amount_before_fee = 0
+            print(q.to_json())
+
+
+class TestQuoteResponse(unittest.TestCase):
+    def test_json_serialization(self):
+        quote = """{
+            "quote": {
+                "sellToken": "0x1111111111111111111111111111111111111111",
+                "buyToken": "0x2222222222222222222222222222222222222222",
+                "receiver": "0x3333333333333333333333333333333333333333",
+                "sellAmount": "123",
+                "buyAmount": "456",
+                "validTo": 7,
+                "appData": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "feeAmount": "789",
+                "kind": "buy",
+                "partiallyFillable": true,
+                "sellTokenBalance": "external",
+                "buyTokenBalance": "erc20"
+            },
+            "from": "0x4444444444444444444444444444444444444444",
+            "expiration": "2022-03-27T16:29:48.650107010Z",
+            "extraField": "that gets ignored"
+        }"""
+        self.assertEqual(QuoteResponse.from_json(json.loads(quote)), QuoteResponse(
+            quote = Quote(
+                sell_token = Address("0x1111111111111111111111111111111111111111"),
+                buy_token = Address("0x2222222222222222222222222222222222222222"),
+                receiver = Address("0x3333333333333333333333333333333333333333"),
+                sell_amount = 123,
+                buy_amount = 456,
+                valid_to = 7,
+                app_data = AppData("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                fee_amount = 789,
+                kind = OrderKind.BUY,
+                partially_fillable = True,
+                sell_token_balance = TokenBalance.EXTERNAL,
+                buy_token_balance = TokenBalance.ERC20,
+            ),
+            from_ = Address("0x4444444444444444444444444444444444444444"),
+            expiration = datetime.fromisoformat("2022-03-27T16:29:48.650107"),
+        ))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -2,7 +2,7 @@ import unittest
 
 from src.fetch.period_slippage import SolverSlippage
 from src.fetch.transfer_file import TokenType, Transfer
-from src.models import AccountingPeriod, Address
+from src.models import AccountingPeriod, Address, AppData
 from tests.e2e.test_internal_trades import TransferType
 
 ONE_ADDRESS = Address("0x1111111111111111111111111111111111111111")
@@ -162,6 +162,21 @@ class TestAccountingPeriod(unittest.TestCase):
             f"time data '{bad_date_string}' does not match format '%Y-%m-%d'",
             str(err.exception),
         )
+
+
+class TestAppData(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(ValueError):
+            AppData("this is not valid")
+
+    def test_valid(self):
+        self.assertEqual(
+            AppData("0x0123456789abcdef0123456789aBcDeF0123456789ABcDef0123456789ABCDEF").value,
+            "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+
+    def test_random(self):
+        self.assertEqual(len(AppData.random().value), 66)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a `CowApi` class for interacting with the CowSwap orderbook API. Specifically, this API implements quoting orders. This is likely not the best place for this API to exist (maybe a separate python repo/package), but I decided to make the PR against this codebase for now.

This change is part of a larger effort to start migrating portions of the withdrawal script from the `gp-v2-contracts` repo here (since withdrawals are used for solver rewards, it felt natural to make a PR here for now). The motivation for this migration is:
- Indexing trade events to get a list of all traded tokens takes a long time. A Dune query is much quicker
- The withdrawal script gets pricing information for each traded token which takes a very long time - using the Dune prices table will likely get a prices for a huge chunk of tokens and hopefully speed things up.
- Learn some Python

For now, this PR is a draft - although the code is ready for review, I'm not sure this is the correct path forward that we should take WRT to computing withdrawals

### Test Plan

Added unit tests for most of the new logic, and an E2E test verifying quoting API works.